### PR TITLE
useTagFurl

### DIFF
--- a/core/components/taglister/elements/snippets/taglister.snippet.php
+++ b/core/components/taglister/elements/snippets/taglister.snippet.php
@@ -177,7 +177,7 @@ foreach ($tagList as $tag => $count) {
     }
     $tagArray['url'] = $modx->makeUrl($target,'',$tagParams);
     if (!empty($useTagFurl)) {
-        $tagArray['url'] = rtrim($tagArray['url'],'/').'/tags/'.str_replace(' ','+',$tag);
+        $tagArray['url'] = rtrim($tagArray['url'],'/').'/'.$tv.'/'.urlencode($tag);
     }
 
     $output[] = $tagLister->getChunk($tpl,$tagArray);

--- a/core/components/taglister/elements/snippets/tolinks.snippet.php
+++ b/core/components/taglister/elements/snippets/tolinks.snippet.php
@@ -44,7 +44,7 @@ $tagKey = $modx->getOption('tagKey',$scriptProperties,'tags');
 $target = !empty($scriptProperties['target']) ? $scriptProperties['target'] : $modx->resource->get('id');
 $tpl = $modx->getOption('tpl',$scriptProperties,'link');
 $cls = $modx->getOption('cls',$scriptProperties,'tl-tag');
-$useTagsFurl = $modx->getOption('useTagsFurl',$scriptProperties,false);
+$useTagFurl = $modx->getOption('useTagFurl',$scriptProperties,false);
 
 /* get items */
 $items = $modx->getOption('items',$scriptProperties,'');
@@ -71,7 +71,7 @@ foreach ($items as $item) {
     $itemArray = array();
     $itemArray['item'] = trim($item);
     $params = array();
-    if (empty($useTagsFurl)) {
+    if (empty($useTagFurl)) {
         $params = array(
             $tagRequestParam => $itemArray['item'],
             $tagKeyVar => $tagKey,
@@ -82,10 +82,9 @@ foreach ($items as $item) {
         $params = array_merge($extraParams,$params);
     }
     $itemArray['url'] = $modx->makeUrl($target,'',$params);
-    if (!empty($useTagsFurl)) {
-         $itemArray['url'] = rtrim($itemArray['url'],'/').'/tags/'.$itemArray['item'];
+    if (!empty($useTagFurl)) {
+         $itemArray['url'] = rtrim($itemArray['url'],'/').'/'.$tagKey.'/'.urlencode($itemArray['item']);
     }
-    $itemArray['url'] = str_replace(' ','+',$itemArray['url']);
     $itemArray['cls'] = $cls;
     $tags[] = $tagLister->getChunk($tpl,$itemArray);
 }


### PR DESCRIPTION
I just fixed some small issues with useTagFurl.
Honestly - I would have rolled back your useTagFurl commits, and just use chunks instead.   it's cleaner.
tagLister's tpl:   `<a href="[[~[[+target]]]]/[[+tagKey]]/[[+tag:urlencode]]">[[+tag]]</a>`

tolinks's tpl:  `<a class="[[+cls]]" href="[[~[[+target]]]]/[[+tagKey]]/[[+tag:urlencode]]">[[+item]]</a>`
_(*\* [[tolinks]] snippet would need those fields sent in itemArray[] )_

anyway - here's the fixes for useTagFurl
thanks.
